### PR TITLE
Add gitignore, simple json, iso8601 date support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+src/main.o
+src/usbtemp.o
+utmp-cli


### PR DESCRIPTION
This PR adds a `.gitignore` file and two switches `-i` and `-j`.

The `-i` switch changes the format of the date to be ISO 8601. This is referred to as `psuedo_iso_8601_mode` in the code only because I did not use a library for the formatting and there may be situations for which the simple formatting does not work.

The `-j` switch does simple printf json formatting. The result contains 2 properties `"date"` and `"temp_c"` or `"temp_f"` depending on the state of the `-f` switch.